### PR TITLE
The select query for nwis_district_cds_by_host should only select the…

### DIFF
--- a/src/main/java/gov/acwi/wqp/etl/nwis/nwisDistrictCdsByHost/NwisDistrictCdsByHostRowMapper.java
+++ b/src/main/java/gov/acwi/wqp/etl/nwis/nwisDistrictCdsByHost/NwisDistrictCdsByHostRowMapper.java
@@ -8,21 +8,17 @@ import org.springframework.jdbc.core.RowMapper;
 
 public class NwisDistrictCdsByHostRowMapper implements RowMapper<NwisDistrictCdsByHost> {
 	
-	private static final String HOST_NAME_COLUMN_NAME = "host_name";
 	private static final String DISTRICT_CD_COLUMN_NAME = "district_cd";
 	private static final String STATE_NAME_COLUMN_NAME = "state_name";
 	private static final String STATE_POSTAL_CD_COLUMN_NAME = "state_postal_cd";
-	private static final String LAST_UPD_DATE_COLUMN_NAME = "last_upd_date";
-	
+
 	@Override
 	public NwisDistrictCdsByHost mapRow(ResultSet rs, int rowNum) throws SQLException {
 		NwisDistrictCdsByHost nwisDistictCds = new NwisDistrictCdsByHost();
-		nwisDistictCds.setHostName(rs.getString(HOST_NAME_COLUMN_NAME));
 		nwisDistictCds.setDistrictCd(rs.getString(DISTRICT_CD_COLUMN_NAME));
 		nwisDistictCds.setStateName(rs.getString(STATE_NAME_COLUMN_NAME));
 		nwisDistictCds.setStatePostalCd(rs.getString(STATE_POSTAL_CD_COLUMN_NAME));
-		nwisDistictCds.setLastUpdDate(LocalDate.parse(rs.getString(LAST_UPD_DATE_COLUMN_NAME)));
-		
+
 		return nwisDistictCds;
 	}
 

--- a/src/main/java/gov/acwi/wqp/etl/orgData/TransformOrgData.java
+++ b/src/main/java/gov/acwi/wqp/etl/orgData/TransformOrgData.java
@@ -54,7 +54,7 @@ public class TransformOrgData {
 		return new JdbcCursorItemReaderBuilder<NwisDistrictCdsByHost>()
 				.dataSource(dataSourceNwis)
 				.name("organizationReader")
-				.sql("select distinct * from nwis_district_cds_by_host")
+				.sql("select distinct district_cd, state_name, state_postal_cd from nwis_district_cds_by_host")
 				.rowMapper(new NwisDistrictCdsByHostRowMapper())
 				.build();
 	}

--- a/src/test/resources/testData/nwis/nwisDistrictCdsByHost/nwisDistrictCdsByHost.xml
+++ b/src/test/resources/testData/nwis/nwisDistrictCdsByHost/nwisDistrictCdsByHost.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0"?>
 <dataset>
-<nwis_district_cds_by_host host_name="nwisin" district_cd="18" state_name="Indiana" state_postal_cd="IN" last_upd_date="2012-08-12"></nwis_district_cds_by_host>
-<nwis_district_cds_by_host host_name="nwismi" district_cd="26" state_name="Michigan" state_postal_cd="MI" last_upd_date="2012-08-12"></nwis_district_cds_by_host>
-<nwis_district_cds_by_host host_name="nwisoh" district_cd="39" state_name="Ohio" state_postal_cd="OH" last_upd_date="2012-08-12"></nwis_district_cds_by_host>
+    <nwis_district_cds_by_host host_name="nwisin"
+                               district_cd="18"
+                               state_name="Indiana"
+                               state_postal_cd="IN"
+                               last_upd_date="2012-08-12"></nwis_district_cds_by_host>
+    <nwis_district_cds_by_host host_name="nwisinsec"
+                               district_cd="18"
+                               state_name="Indiana"
+                               state_postal_cd="IN"
+                               last_upd_date="2012-08-12"></nwis_district_cds_by_host>
+    <nwis_district_cds_by_host host_name="nwismi"
+                               district_cd="26"
+                               state_name="Michigan"
+                               state_postal_cd="MI"
+                               last_upd_date="2012-08-12"></nwis_district_cds_by_host>
+    <nwis_district_cds_by_host host_name="nwisoh"
+                               district_cd="39"
+                               state_name="Ohio"
+                               state_postal_cd="OH"
+                               last_upd_date="2012-08-12"></nwis_district_cds_by_host>
 </dataset>


### PR DESCRIPTION
… columns used in the transformation to ensure that the district_cd is unique.