### PR TITLE
WQP-1649 Updated spring-boot-starter-parent to 2.3.10.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.3.10.RELEASE</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
  Version 2.4.X had unit test failures.